### PR TITLE
Drag-and-drop

### DIFF
--- a/Pilcrow.xcodeproj/project.pbxproj
+++ b/Pilcrow.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		92B1755F264D77020016C279 /* DividerContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B1755E264D77020016C279 /* DividerContent.swift */; };
 		92B17561264D77D10016C279 /* DividerBlockViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B17560264D77D10016C279 /* DividerBlockViewModel.swift */; };
 		92B17563264D77F60016C279 /* DividerBlockCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B17562264D77F60016C279 /* DividerBlockCellView.swift */; };
+		92C2262A265421A200FB5D97 /* DocumentEditorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C22629265421A200FB5D97 /* DocumentEditorTests.swift */; };
 		92C581172644472800E062A0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C581162644472800E062A0 /* AppDelegate.swift */; };
 		92C581192644472800E062A0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C581182644472800E062A0 /* SceneDelegate.swift */; };
 		92C5811B2644472800E062A0 /* DocumentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C5811A2644472800E062A0 /* DocumentViewController.swift */; };
@@ -93,6 +94,7 @@
 		92B1755E264D77020016C279 /* DividerContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerContent.swift; sourceTree = "<group>"; };
 		92B17560264D77D10016C279 /* DividerBlockViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerBlockViewModel.swift; sourceTree = "<group>"; };
 		92B17562264D77F60016C279 /* DividerBlockCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerBlockCellView.swift; sourceTree = "<group>"; };
+		92C22629265421A200FB5D97 /* DocumentEditorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentEditorTests.swift; sourceTree = "<group>"; };
 		92C581132644472800E062A0 /* Pilcrow.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Pilcrow.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92C581162644472800E062A0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92C581182644472800E062A0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -279,6 +281,7 @@
 				922590D4264718A5000113B3 /* DocumentTests.swift */,
 				922590D826471C8D000113B3 /* NumberedListItemContentTests.swift */,
 				92C5812F2644472900E062A0 /* Info.plist */,
+				92C22629265421A200FB5D97 /* DocumentEditorTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -445,6 +448,7 @@
 			files = (
 				922590D926471C8D000113B3 /* NumberedListItemContentTests.swift in Sources */,
 				922590D5264718A5000113B3 /* DocumentTests.swift in Sources */,
+				92C2262A265421A200FB5D97 /* DocumentEditorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/Models/Document/Document.swift
+++ b/Source/Models/Document/Document.swift
@@ -3,15 +3,8 @@ import Foundation
 struct Document: Codable, Equatable {
     static let fileExtension = "pilcrow"
     
-    let id: String
-    var name: String
-    var blocks: [Block]
-    
-    init(name: String = "Untitled", blocks: [Block] = []) {
-        self.id = UUID().uuidString
-        self.name = name
-        self.blocks = blocks
-    }
+    var name: String = "Untitled"
+    var blocks: [Block] = []
 }
 
 extension Document {

--- a/Source/Models/Document/Edit/DocumentEditor.swift
+++ b/Source/Models/Document/Edit/DocumentEditor.swift
@@ -25,6 +25,13 @@ final class DocumentEditor {
         }
     }
     
+    func moveBlock(_ block: Block, to destinationRow: Int) {
+        guard let sourceRow = index(of: block) else { return }
+        
+        let block = document.blocks.remove(at: sourceRow)
+        document.blocks.insert(block, at: destinationRow)
+    }
+
     func toggleCompletion(for block: Block) -> EditResult? {
         guard var content = block.content as? TodoContent else { return nil }
         

--- a/Source/Models/Document/Edit/DocumentEditor.swift
+++ b/Source/Models/Document/Edit/DocumentEditor.swift
@@ -25,9 +25,10 @@ final class DocumentEditor {
         }
     }
     
-    func moveBlock(_ block: Block, to destinationRow: Int) {
+    func moveBlock(_ block: Block, to row: Int) {
         guard let sourceRow = index(of: block) else { return }
         
+        let destinationRow = min(row, document.blocks.count - 1)
         let block = document.blocks.remove(at: sourceRow)
         document.blocks.insert(block, at: destinationRow)
     }

--- a/Source/View Controllers/DocumentViewController.swift
+++ b/Source/View Controllers/DocumentViewController.swift
@@ -347,17 +347,7 @@ final class DocumentViewController: UIViewController {
     }
 }
 
-extension DocumentViewController: UICollectionViewDelegate {
-    func collectionView(_ collectionView: UICollectionView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
-        UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: { actions in
-            UIMenu(children: [
-                UIAction(title: "Delete", attributes: [.destructive], handler: { [weak self] _ in
-                    self?.deleteBlock(at: indexPath)
-                })
-            ])
-        })
-    }
-}
+extension DocumentViewController: UICollectionViewDelegate {}
 
 extension DocumentViewController: TodoCellDelegate {
     func todoCellDidToggleCheckBox(cell: TodoBlockCellView) {

--- a/Source/View Controllers/DocumentViewController.swift
+++ b/Source/View Controllers/DocumentViewController.swift
@@ -43,8 +43,12 @@ final class DocumentViewController: UIViewController {
     
     // MARK: - Document
     
-    private func save() {
+    private func scheduleSave() {
         // TODO: throttle/debounce saves
+        save()
+    }
+    
+    private func save() {
         do {
             try DocumentStore.shared.saveDocument(document)
         } catch {
@@ -397,6 +401,7 @@ extension DocumentViewController: UICollectionViewDropDelegate {
         
         editor.moveBlock(block, to: destinationIndexPath.row)
         updateDataSource()
+        save()
         
         coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
     }

--- a/Source/View Controllers/DocumentViewController.swift
+++ b/Source/View Controllers/DocumentViewController.swift
@@ -374,6 +374,10 @@ extension DocumentViewController: UICollectionViewDragDelegate {
         
         return [dragItem]
     }
+    
+    func collectionView(_ collectionView: UICollectionView, dragSessionIsRestrictedToDraggingApplication session: UIDragSession) -> Bool {
+        true
+    }
 }
 
 extension DocumentViewController: UICollectionViewDropDelegate {

--- a/Source/View Controllers/DocumentViewController.swift
+++ b/Source/View Controllers/DocumentViewController.swift
@@ -368,11 +368,8 @@ extension DocumentViewController: TextCellDelegate {
 
 extension DocumentViewController: UICollectionViewDragDelegate {
     func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
-        let block = document.blocks[indexPath.row]
-        let dragItem = UIDragItem(itemProvider: NSItemProvider())
-        dragItem.localObject = block
-        
-        return [dragItem]
+        // Use empty NSItemProvider since we'll rely on the sourceIndexPath when dropping to access block
+        [UIDragItem(itemProvider: NSItemProvider())]
     }
     
     func collectionView(_ collectionView: UICollectionView, dragSessionIsRestrictedToDraggingApplication session: UIDragSession) -> Bool {
@@ -382,7 +379,7 @@ extension DocumentViewController: UICollectionViewDragDelegate {
 
 extension DocumentViewController: UICollectionViewDropDelegate {
     func collectionView(_ collectionView: UICollectionView, canHandle session: UIDropSession) -> Bool {
-        true
+        session.localDragSession != nil
     }
     
     func collectionView(_ collectionView: UICollectionView, dropSessionDidUpdate session: UIDropSession, withDestinationIndexPath destinationIndexPath: IndexPath?) -> UICollectionViewDropProposal {

--- a/Tests/DocumentEditorTests.swift
+++ b/Tests/DocumentEditorTests.swift
@@ -17,6 +17,8 @@ class DocumentEditorTests: XCTestCase {
         )
     }
     
+    // MARK: - Moves
+    
     func testMoveBlockToBeginning() {
         let editor = DocumentEditor(document: simpleDocument)
         editor.moveBlock(paragraphBlock, to: 0)

--- a/Tests/DocumentEditorTests.swift
+++ b/Tests/DocumentEditorTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import Pilcrow
+
+class DocumentEditorTests: XCTestCase {
+    private let paragraphBlock = ParagraphContent(text: "paragraph").asBlock()
+    private let dividerBlock = DividerContent().asBlock()
+    private let headingBlock = HeadingContent(text: "heading").asBlock()
+    
+    private var simpleDocument: Document {
+        Document(
+            name: "Test",
+            blocks: [
+                paragraphBlock,
+                dividerBlock,
+                headingBlock
+            ]
+        )
+    }
+    
+    func testMoveBlockToBeginning() {
+        let editor = DocumentEditor(document: simpleDocument)
+        editor.moveBlock(paragraphBlock, to: 0)
+        
+        let expectedDocument = Document(name: "Test", blocks: [
+            paragraphBlock,
+            dividerBlock,
+            headingBlock
+        ])
+        
+        XCTAssertEqual(editor.document, expectedDocument)
+    }
+    
+    func testMoveBlockToEnd() {
+        let document = simpleDocument
+        let editor = DocumentEditor(document: document)
+        editor.moveBlock(paragraphBlock, to: document.blocks.count - 1)
+        
+        let expectedDocument = Document(name: "Test", blocks: [
+            dividerBlock,
+            headingBlock,
+            paragraphBlock
+        ])
+        
+        XCTAssertEqual(editor.document, expectedDocument)
+    }
+    
+    func testMoveBlockPastEndInsertsAtEnd() {
+        let document = simpleDocument
+        let editor = DocumentEditor(document: document)
+        editor.moveBlock(paragraphBlock, to: 100)
+        
+        let expectedDocument = Document(name: "Test", blocks: [
+            dividerBlock,
+            headingBlock,
+            paragraphBlock
+        ])
+        
+        XCTAssertEqual(editor.document, expectedDocument)
+    }
+}


### PR DESCRIPTION
Adds support for drag-and-drop to reorder blocks in a document. I couldn't get the diffable data source `reorderingHandlers`  to work (https://developer.apple.com/documentation/uikit/uicollectionviewdiffabledatasource/3600965-reorderinghandlers?changes=_8), so did it the manual way.

![drag-drop](https://user-images.githubusercontent.com/21447/118693294-efdd2a80-b7d8-11eb-84bf-6ce91fb32b24.gif)